### PR TITLE
Remove mobilecss since it does not work

### DIFF
--- a/settings.php
+++ b/settings.php
@@ -143,9 +143,6 @@ $CFG->cronclionly = 1; // changed to avoid schools change it
     $CFG->proxypassword = $agora['proxy']['pass'];
 }*/
 
-
-$CFG->mobilecssurl = $CFG->wwwroot.'/theme/xtec2/mobile/style.php';
-
 $CFG->customusermenuitems = "grades,grades|/grade/report/mygrades.php|grades
 messages,message|/message/index.php|message
 badges,badges|/badges/mybadges.php|award


### PR DESCRIPTION
With new versions of the Moodle App. This css only cause problems for admins that want to have their own css.
